### PR TITLE
fix: prisma start issue in prod

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,9 @@
   "version": "1.0.0",
   "main": "index.js",
   "scripts": {
-    "dev": "ts-node-dev --respawn --transpile-only src/index.ts",
-    "start": "tsc -b && node dist/index.js"
+    "start": "npm run build && node dist/index.js",
+    "build": "tsc -b && npm run copy:prisma",
+    "copy:prisma": "node ./scripts/copyPrisma.js"
   },
   "keywords": [],
   "author": "Gyanranjan Patra",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "main": "index.js",
   "scripts": {
+    "dev": "ts-node-dev --respawn --transpile-only src/index.ts",
     "start": "npm run build && node dist/index.js",
     "build": "tsc -b && npm run copy:prisma",
     "copy:prisma": "node ./scripts/copyPrisma.js"

--- a/scripts/copyPrisma.js
+++ b/scripts/copyPrisma.js
@@ -1,0 +1,8 @@
+const fs = require("fs");
+const path = require("path");
+
+const src = path.join(__dirname, "..", "src", "generated");
+const dest = path.join(__dirname, "..", "dist", "generated");
+
+fs.cpSync(src, dest, { recursive: true });
+console.log("✔ Prisma client copied");


### PR DESCRIPTION
When we start application in prod server it gets build failed because it doesn't find the generated file 

We have to copy the generated file from src to dist else remove it prisma handle it by default as app getting more complex we need that so i make it copy during build process from src/generated to dist/generated